### PR TITLE
Version bump (to 1.4.2) as a result of fix for #10

### DIFF
--- a/fdsc.user.js
+++ b/fdsc.user.js
@@ -6,7 +6,7 @@
 // @contributor angussidney
 // @contributor rene
 // @attribution TinyGiant
-// @version     1.4.1
+// @version     1.4.2
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fdsc.user.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fdsc.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues


### PR DESCRIPTION
No version bump was done so these changes are not caught by userscript update functions.  Bump version accordingly.

See #10 for what prompted the last commit, and why I'm making this PR to actually do the version bump (which was *not* done previously)