### PR TITLE
Autoflagging: keep the indicator visible on hover

### DIFF
--- a/autoflagging.user.js
+++ b/autoflagging.user.js
@@ -13,14 +13,14 @@
 // ==/UserScript==
 
 (function () {
-    'use strict';
+	'use strict';
 	//console.log("Autoflagging Information started.");
-    
+
 	// Inject CSS
 	var link = window.document.createElement('link');
 	link.rel = 'stylesheet';
 	link.type = 'text/css';
-	link.href = 'data:text/css, .ai-information { float: right; } .ai-flag, .ai-spinner { height: 1.5em; }';
+	link.href = 'data:text/css, .ai-information { position: absolute; bottom: 1px; right: 3px; } .ai-flag, .ai-spinner { height: 1.5em; }';
 	document.getElementsByTagName("head")[0].appendChild(link);
 
 	// Constants
@@ -32,11 +32,11 @@
 	autoflagging.selector = ".user-" + autoflagging.smokeyID + " .message a[href^='" + autoflagging.prefix + "']";
 	// MS links can appear in other Smokey messages too (like feedback on an old post, or conflicted feedback).
 	// Fortunately, those are direct links like https://metasmoke.erwaysoftware.com/post/56004
-	
+
 	// TODO: Sometimes, Smokey reports don't contain an MS link (because of the chat message limit length).
 	// We either need to find a work-around, e.g. by using the direct link in the chat message,
 	// or wait until this feature request is implemented: https://github.com/Charcoal-SE/SmokeDetector/issues/488
-	
+
 	/*!
 	 * Decorates a jQuery DOM element with autoflagging information from the data.
 	 *
@@ -45,7 +45,7 @@
 	autoflagging.decorate = function (element, data) {
 		// Remove previous information (like a spinner)
 		element.find(".ai-information").remove();
-		
+
 		var html = "<span class=\"ai-information\">";
 		if (data.flagged) {
 			// TODO: ensure that this is nicely displayed when more than one flag is cast
@@ -55,8 +55,14 @@
 		}
 		html += "</span>";
 		element.append(html);
+		element.parents(".message").on("mouseenter", function () {
+			var $meta = $(this).find(".meta")
+			$(this).find(".ai-information").css("margin-right", $meta.width() + +$meta.css("padding-left").slice(0, -2))
+		}).on("mouseleave", function () {
+			$(this).find(".ai-information").css("margin-right", 0)
+		});
 	};
-	
+
 	/*!
 	 * Decorates a jQuery DOM element with a spinner.
 	 */
@@ -65,7 +71,7 @@
 			"<img class=\"ai-spinner\" src=\"//i.stack.imgur.com/icRVf.gif\" title=\"Loading autoflagging information ...\" />" +
 			"</span>");
 	};
-	
+
 	/*!
 	 * Calls the API to get information about multiple posts at once, considering the paging system of the API.
 	 * It will use the results to decorate the Smokey reports which are already on the page.
@@ -81,7 +87,7 @@
 			for (var i = 0; i < data.items.length; i++) {
 				autoflagData[data.items[i].link] = data.items[i].autoflagged;
 			}
-			
+
 			// Loop over all Smokey reports and decorate them
 			$(autoflagging.selector).each(function() {
 				var postURL = $(this).attr('href').substring(autoflagging.prefix.length);
@@ -90,14 +96,14 @@
 					return;
 				autoflagging.decorate($(this).parent(), autoflagData[postURL]);
 			});
-			
+
 			if (data.has_more) {
 				// There are more items on the next 'page'
 				autoflagging.callAPI(urls, ++page);
 			}
-		});	
+		});
 	};
-	
+
 	// Wait for the chat messages to be loaded.
 	var chat = $("#chat");
 	chat.bind("DOMSubtreeModified", function() {
@@ -118,7 +124,7 @@
 			autoflagging.callAPI(urls, 1);
 		}
 	});
-	
+
 	// Subscribe to chat events
 	CHAT.addEventHandlerHook(function(e, n, s) {
 		if (e.event_type == 1 && e.user_id == autoflagging.smokeyID) {

--- a/autoflagging.user.js
+++ b/autoflagging.user.js
@@ -20,7 +20,11 @@
 	var link = window.document.createElement('link');
 	link.rel = 'stylesheet';
 	link.type = 'text/css';
-	link.href = 'data:text/css, .ai-information { position: absolute; bottom: 1px; right: 3px; } .ai-flag, .ai-spinner { height: 1.5em; }';
+	link.href = 'data:text/css, ' +
+    '.ai-information { position: absolute; bottom: 1px; right: -25px; }' +
+    '.ai-information>span { display: inline-block; width: 0; position: absolute; transform: rotate(90deg); transform-origin: bottom; }' +
+    '.ai-information>span>span { display: inline-block; margin-left: -1.5em }' +
+    '.ai-flag, .ai-spinner { height: 1.5em; }';
 	document.getElementsByTagName("head")[0].appendChild(link);
 
 	// Constants
@@ -49,17 +53,16 @@
 		var html = "<span class=\"ai-information\">";
 		if (data.flagged) {
 			// TODO: ensure that this is nicely displayed when more than one flag is cast
-			html += data.names + " <img class=\"ai-flag\" src=\"//i.stack.imgur.com/CpHts.png\" title=\"This post has been autoflagged\"/>";
+			html += "<img class=\"ai-flag\" src=\"//i.stack.imgur.com/CpHts.png\" title=\"This post has been autoflagged\"/><span style=\"display: none\"><span>" + data.names + "</span></span>";
 		} else {
 			html += "<img class=\"ai-flag\" src=\"//i.stack.imgur.com/djVc2.png\" title=\"This post has not been autoflagged\"/>";
 		}
 		html += "</span>";
 		element.append(html);
 		element.parents(".message").on("mouseenter", function () {
-			var $meta = $(this).find(".meta")
-			$(this).find(".ai-information").css("margin-right", $meta.width() + +$meta.css("padding-left").slice(0, -2))
+			$(this).find(".ai-information>span").css('display', '')
 		}).on("mouseleave", function () {
-			$(this).find(".ai-information").css("margin-right", 0)
+      $(this).find(".ai-information>span").css('display', 'none ')
 		});
 	};
 


### PR DESCRIPTION
This makes the indicator move over to the left of the flag/star/reply buttons when the message is hovered.