### PR TITLE
Collapse "deleted" reports

### DIFF
--- a/autoflagging.css
+++ b/autoflagging.css
@@ -35,6 +35,13 @@ div.message {
 .ai-deleted:not(:hover), .ai-flag-count.ai-not-autoflagged {
   opacity: 0.5;
 }
+.ai-deleted {
+    max-height: 1.4em;
+    transition: all 0.5s ease;
+}
+.ai-deleted:hover {
+    max-height: 3em;
+}
 .ai-flag-count {
   color: inherit;
   text-decoration: none !important;

--- a/autoflagging.css
+++ b/autoflagging.css
@@ -37,6 +37,7 @@ div.message {
 }
 .ai-deleted {
     max-height: 1.5em;
+    overflow: hidden;
     transition: all 0.5s ease;
 }
 .ai-deleted:hover {

--- a/autoflagging.css
+++ b/autoflagging.css
@@ -36,7 +36,7 @@ div.message {
   opacity: 0.5;
 }
 .ai-deleted {
-    max-height: 1.4em;
+    max-height: 1.5em;
     transition: all 0.5s ease;
 }
 .ai-deleted:hover {


### PR DESCRIPTION
Don't show 2 lines for deleted ("handled") reports,
Expand them again on hover.

What do you think, @Glorfindel83 / @j-f1?