### PR TITLE
metapi reconnectingSocket, AIM: use metapi

### DIFF
--- a/autoflagging/autoflagging.user.js
+++ b/autoflagging/autoflagging.user.js
@@ -7,7 +7,7 @@
 // @contributor angussidney
 // @contributor ArtOfCode
 // @contributor Cerbrus
-// @version     0.13
+// @version     0.13.1
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.user.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/metapi/metapi.js
+++ b/metapi/metapi.js
@@ -8,6 +8,7 @@ window.metapi = {};
 
   // Private: Dictionary of API keys to metapi.WebSockets
   var sockets = {};
+  var pendingSockets = [];
 
   // Private: Dictionary of MS database field names to bitstring indexes
   var api_field_mappings = {};
@@ -23,7 +24,8 @@ window.metapi = {};
     console.error("Failed to fetch API field mappings from MS API:", jqXhr);
   });
 
-  $.getScript("https://raw.githubusercontent.com/joewalnes/reconnecting-websocket/f8055b77ba75e5d564ffb50d20a483bdd7edccdf/reconnecting-websocket.min.js");
+  $.getScript("https://raw.githubusercontent.com/joewalnes/reconnecting-websocket/f8055b77ba75e5d564ffb50d20a483bdd7edccdf/reconnecting-websocket.min.js",
+    metapi.watchPendingSockets);
 
   // Public: Enable debug mode by setting this to true. Calls to metapi.debug will log output.
   metapi.debugMode = false;
@@ -174,19 +176,32 @@ window.metapi = {};
    * @param address  the address of the websocket to connect to
    * @param onOpen   a callback function for the websocket's open event
    */
-  metapi.WebSocket = function (address, onOpen, onClose) {
+  metapi.WebSocket = function (address, onOpen) {
     var callbacks = [];
+    var closeCallbacks = [];
 
     var getCallbacks = function () {
       return callbacks;
+    };
+
+    var getCloseCallbacks = function () {
+      return closeCallbacks;
     };
 
     var addCallback = function (callback) {
       callbacks.push(callback);
     };
 
+    var addCloseCallback = function (callback) {
+      callbacks.push(callback);
+    };
+
     var removeCallback = function (callback) {
-      callbacks.pop(callback);
+      closeCallbacks.pop(callback);
+    };
+
+    var removeCloseCallback = function (callback) {
+      closeCallbacks.pop(callback);
     };
 
     var conn = new ReconnectingWebSocket(address);
@@ -195,13 +210,15 @@ window.metapi = {};
       conn.onopen = onOpen;
     }
 
-    if (onClose && typeof onClose === "function") {
-      conn.onclose = onClose;
-    }
-
     conn.onmessage = function (data) {
       for (var i = 0; i < callbacks.length; i++) {
         callbacks[i](data);
+      }
+    };
+
+    conn.onclose = function (data) {
+      for (var i = 0; i < closeCallbacks.length; i++) {
+        closeCallbacks[i](data);
       }
     };
 
@@ -219,6 +236,13 @@ window.metapi = {};
       getCallbacks: getCallbacks,
 
       /**
+       * Retrieves an arrary of existing callbacks for the socket close.
+       *
+       * @returns an array of functions, each of which is a socket close
+       */
+      getCloseCallbacks: getCloseCallbacks,
+
+      /**
        * Appends a message callback function to the callbacks list.
        *
        * @param callback  a function with optional data parameter, used as a callback to the message event
@@ -226,11 +250,25 @@ window.metapi = {};
       addCallback: addCallback,
 
       /**
+       * Appends a socket close callback function to the close callbacks list.
+       *
+       * @param callback  a function with optional data parameter, used as a callback to the socket close event
+       */
+      addCloseCallback: addCloseCallback,
+
+      /**
        * Given a reference to a callback function, removes that function from the message callbacks list.
        *
        * @param callback  a reference to a callback function already in the socket's message callbacks list
        */
       removeCallback: removeCallback,
+
+      /**
+       * Given a reference to a close callback function, removes that function from the message close callbacks list.
+       *
+       * @param callback  a reference to a close callback function already in the socket's message close callbacks list
+       */
+      removeCloseCallback: removeCloseCallback,
 
       /**
        * Sends a message through the websocket.
@@ -393,10 +431,19 @@ window.metapi = {};
    * @param messageCallback  a callback function accepting a single data parameter containing a message received on the
    *                         websocket
    */
-  metapi.watchSocket = function (key, messageCallback) {
+  metapi.watchSocket = function (key, messageCallback, closeCallback) {
+    if (!ReconnectingWebSocket) {
+      pendingSockets.push({
+        key: key,
+        messageCallback: messageCallback,
+        closeCallback: closeCallback
+      });
+      return;
+    }
+
     var sock;
     if (!sockets.hasOwnProperty(key)) {
-      sockets[key] = new metapi.ReconnectingWebSocket("wss://metasmoke.erwaysoftware.com/cable", function () {
+      sockets[key] = new metapi.WebSocket("wss://metasmoke.erwaysoftware.com/cable", function () {
         this.send(JSON.stringify({
           identifier: JSON.stringify({
             channel: "ApiChannel",
@@ -409,5 +456,19 @@ window.metapi = {};
     sock = sockets[key];
 
     sock.addCallback(messageCallback);
+
+    if (closeCallback) {
+      sock.addCloseCallback(closeCallback);
+    }
+  };
+
+  /**
+   * Registers sockets / listeners for socckets that were requested while an dependency was still loading.
+   */
+  metapi.watchPendingSockets = function () {
+    while (pendingSockets.length) {
+      var options = pendingSockets.shift();
+      metapi.watchSocket(options.key, options.messageCallback);
+    }
   };
 })();

--- a/metapi/metapi.js
+++ b/metapi/metapi.js
@@ -24,7 +24,7 @@ window.metapi = {};
     console.error("Failed to fetch API field mappings from MS API:", jqXhr);
   });
 
-  $.getScript("https://raw.githubusercontent.com/joewalnes/reconnecting-websocket/f8055b77ba75e5d564ffb50d20a483bdd7edccdf/reconnecting-websocket.min.js",
+  $.getScript("https://cdn.rawgit.com/joewalnes/reconnecting-websocket/fd7c819b/reconnecting-websocket.js",
     metapi.watchPendingSockets);
 
   // Public: Enable debug mode by setting this to true. Calls to metapi.debug will log output.

--- a/metapi/metapi.js
+++ b/metapi/metapi.js
@@ -24,8 +24,14 @@ window.metapi = {};
     console.error("Failed to fetch API field mappings from MS API:", jqXhr);
   });
 
+  // Load the ReconnectingWebSocket API and register any pending sockets on load.
   $.getScript("https://cdn.rawgit.com/joewalnes/reconnecting-websocket/fd7c819b/reconnecting-websocket.js",
-    metapi.watchPendingSockets);
+    function () {
+      while (pendingSockets.length) {
+        var options = pendingSockets.shift();
+        metapi.watchSocket(options.key, options.messageCallback);
+      }
+    });
 
   // Public: Enable debug mode by setting this to true. Calls to metapi.debug will log output.
   metapi.debugMode = false;
@@ -193,11 +199,11 @@ window.metapi = {};
     };
 
     var addCloseCallback = function (callback) {
-      callbacks.push(callback);
+      closeCallbacks.push(callback);
     };
 
     var removeCallback = function (callback) {
-      closeCallbacks.pop(callback);
+      callbacks.pop(callback);
     };
 
     var removeCloseCallback = function (callback) {
@@ -459,16 +465,6 @@ window.metapi = {};
 
     if (closeCallback) {
       sock.addCloseCallback(closeCallback);
-    }
-  };
-
-  /**
-   * Registers sockets / listeners for socckets that were requested while an dependency was still loading.
-   */
-  metapi.watchPendingSockets = function () {
-    while (pendingSockets.length) {
-      var options = pendingSockets.shift();
-      metapi.watchSocket(options.key, options.messageCallback);
     }
   };
 })();


### PR DESCRIPTION
@ArtOfCode- / @Glorfindel83  please review:

I moved the ReconnectingWebSocket usage to metapi and implemented metapi for the websocket in AIM.
The code dealing with `pendingSockets` is to allow other scripts to call `metapi.watchSocket`, even if `ReconnectingWebSocket` isn't loaded yet.

`watchSocket` now also allows for a close handler to be passed.