### PR TITLE
Resolved blur not disappearing when save button clicked

### DIFF
--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -951,6 +951,8 @@
       const value = input.val();
       if (value && value.length === fire.constants.metaSmokeCodeLength)
         callback(value);
+
+      closePopup();
     },
     /**
      * Close all popup windows and open the "Request write token" popup.


### PR DESCRIPTION
I added a `closePopup()` call to the callback on the save button, which seems to resolve issue #87, although you may want tot move the call to somewhere which makes more sense. I don't really know the codebase.