### PR TITLE
Exclude gasmask from channels

### DIFF
--- a/gas-mask-se/gas-mask-se.user.js
+++ b/gas-mask-se/gas-mask-se.user.js
@@ -13,6 +13,7 @@
 // @include       *://*superuser.com/*
 // @include       *://*stackapps.com/*
 // @include       *://*askubuntu.com/*
+// @exclude       *://*stackoverflow.com/c/*
 // @version       1.3
 // ==/UserScript==
 


### PR DESCRIPTION
This makes sense because there won't be spam on channels, and not excluding it will block community from posting images (which happens at the beginning of a channel)