### PR TITLE
Remove reason weight display from FIRE

### DIFF
--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -1175,7 +1175,7 @@
       .append(
         _('div', {
           'fire-tooltip': emojiOrImage('clipboard')
-            .append(` - The reported post is a${suffix} ${postType.toLowerCase()}.\nReason weight: ${d.reason_weight}\n\n${d.why}`)
+            .append(` - The reported post is a${suffix} ${postType.toLowerCase()}.\n\n${d.why}`)
             .html()
         })
         .append(_('h2', 'fire-post-title')


### PR DESCRIPTION
It's already covered in two places: Smokey and AIM. Also, FIRE always shows `undefined` for this so it's currently useless.