### PR TITLE
SIM: Version 0.5.1

### DIFF
--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -58,13 +58,14 @@
     });
   };
 
-  const stacksModal = $(`<aside class="js-modal-overlay js-modal-close" tabindex="-1" role="dialog" aria-hidden="true">
-  <div class="s-modal--dialog js-modal-dialog w80 wmx8" role="document">
-    <h2 class="s-modal--header sim--modal-header"></h2>
-    <div class="s-modal--body sim--modal-content"></div>
-    <a class="s-modal--close s-btn s-btn__muted js-modal-close" href="#" aria-label="Close">&times;</a>
-  </div>
-</aside>`);
+  const stacksModal = $(`
+    <aside class="js-modal-overlay js-modal-close" tabindex="-1" role="dialog" aria-hidden="true">
+      <div class="s-modal--dialog js-modal-dialog w80 wmx8" role="document">
+        <h2 class="s-modal--header sim--modal-header"></h2>
+        <div class="s-modal--body sim--modal-content"></div>
+        <a class="s-modal--close s-btn s-btn__muted js-modal-close" href="#" aria-label="Close">&times;</a>
+      </div>
+    </aside>`);
 
   const displayDialog = postData => {
     const modal = stacksModal.clone();

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -4,6 +4,7 @@
 // @version      0.4.2
 // @description  Dig up information about how SmokeDetector handled a post.
 // @author       ArtOfCode
+// @contributor  Makyen
 // @match       *://*.stackexchange.com/*
 // @match       *://*.stackoverflow.com/*
 // @match       *://*.superuser.com/*

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SIM - SmokeDetector Info for Moderators
 // @namespace    https://charcoal-se.org/
-// @version      0.4.2
+// @version      0.5.1
 // @description  Dig up information about how SmokeDetector handled a post.
 // @author       ArtOfCode
 // @contributor  Makyen

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -136,7 +136,10 @@
       const feedbacks = feedbacksJson.items;
       const uniques = [...(new Set(feedbacks.map(f => f.feedback_type.charAt(0))))];
       let fbType;
-      if (uniques.length === 1) {
+      if (uniques.length === 0) {
+        fbType = 'No Feedback';
+      }
+      else if (uniques.length === 1) {
         fbType = feedbacks[0].feedback_type;
       }
       else {

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -21,7 +21,7 @@
 // @downloadURL  https://github.com/Charcoal-SE/userscripts/raw/master/sim/sim.user.js
 // ==/UserScript==
 
-/* globals StackExchange */
+/* globals StackExchange, $ */
 
 (() => {
   const msAPIKey = '5a70b21ec1dd577d6ce36d129df3b0262b7cec2cd82478bbd8abdc532d709216';

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -25,6 +25,10 @@
 /* globals StackExchange, $ */
 
 (() => {
+  if (window.location.pathname.indexOf('/c/') === 0) {
+    // Don't run on Teams
+    return;
+  }
   const msAPIKey = '5a70b21ec1dd577d6ce36d129df3b0262b7cec2cd82478bbd8abdc532d709216';
 
   const isNato = location.pathname === '/tools/new-answers-old-questions';


### PR DESCRIPTION
Display 'No Feedback' when there's no feedback
Improve attaching. Attach to posts:
  earlier in page load
  after inline edits
  after other page modification
  on NATO w/ and w/o NATO Enhancements
  handle the .post-menu-container which SE may, or may not, use
  in review queues
  in close-vote popups