### PR TITLE
[review-shortcuts] Ignore shortcuts while the comment box is focused

### DIFF
--- a/review-keyboard-shortcuts/review-shortcuts.user.js
+++ b/review-keyboard-shortcuts/review-shortcuts.user.js
@@ -67,7 +67,7 @@ $(document).ready(() => {
     }
   });
 
-  $(document).on('keydown', 'input', ev => {
+  $(document).on('keydown', 'input, textarea', ev => {
     ev.stopPropagation();
   });
 });


### PR DESCRIPTION
Previously, if the user typed a comment containing (e.g.) 't', 'n', or 'f', the script would instantly take action on the review item. This commit ignores shortcuts while the user is typing in a `textarea`.