### PR TITLE
AIM: Version 0.31: use shrink fade CSS for .ai-deleted

### DIFF
--- a/autoflagging/autoflagging.meta.js
+++ b/autoflagging/autoflagging.meta.js
@@ -8,7 +8,7 @@
 // @contributor ArtOfCode
 // @contributor Cerbrus
 // @contributor Makyen
-// @version     0.30
+// @version     0.31
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/autoflagging/autoflagging.user.js
+++ b/autoflagging/autoflagging.user.js
@@ -8,7 +8,7 @@
 // @contributor ArtOfCode
 // @contributor Cerbrus
 // @contributor Makyen
-// @version     0.30
+// @version     0.31
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/autoflagging/autoflagging.user.js
+++ b/autoflagging/autoflagging.user.js
@@ -572,7 +572,9 @@ body:not(.aim-disable-deleted-format) .message.ai-deleted:not(:hover):not(.fireC
       const titles = Object.keys(simpleFeedbacksByType)
         .filter(feedbackType => feedbackType !== defaultFeedbackType)
         .map(feedbackType => feedbackType + ": " + simpleFeedbacksByType[feedbackType].join(", "));
-      titles.unshift(defaultFeedbackTitle);
+      if (defaultFeedbackTitle) {
+        titles.unshift(defaultFeedbackTitle);
+      }
       $feedback.append(
         $("<span/>").addClass("ai-feedback-info")
           .addClass("ai-feedback-info-" + defaultFeedbackType)


### PR DESCRIPTION
AIM: Version 0.31
* Use shrink-fade CSS from SOCVR's URRS for .ai-deleted.
* Additional CSS and JS changes to reduce display conflict with timestamp.