### PR TITLE
SIM: Make "smokey" quicklink a proper link (in addition to its normal function as a button)

### DIFF
--- a/sim/package-lock.json
+++ b/sim/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sim",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "sim",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "(MIT OR Apache-2.0)",
       "devDependencies": {
         "eslint": "^8.18.0",

--- a/sim/package.json
+++ b/sim/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sim",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Dig up information on how SmokeDetector handled a post.",
   "scripts": {
     "test": "xo"

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         SIM - SmokeDetector Info for Moderators
 // @namespace    https://charcoal-se.org/
-// @version      0.7.0
+// @version      0.7.1
 // @description  Dig up information about how SmokeDetector handled a post.
 // @author       ArtOfCode
 // @contributor  Makyen

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -267,10 +267,11 @@
         if (!id) {
           return;
         }
+        const type = $e.hasClass('question') ? 'questions' : 'a';
         const apiParam = getCurrentSiteAPIParam();
         const msUri = `https://metasmoke.erwaysoftware.com/api/v2.0/posts/uid/${apiParam}/${id}?key=${msAPIKey}`;
         const $this = $(this);
-        $this.append(`<div class="flex--item"><button class="s-btn s-btn__link sim-get-info" data-request="${msUri}">Smokey</button></div>`);
+        $this.append(`<div class="flex--item"><a href="https://metasmoke.erwaysoftware.com/posts/by-url?url=//${location.host}/${type}/${id}" class="sim-get-info" data-request="${msUri}">Smokey</button></div>`);
         /* Temporarily removed due to NATOEnhancements and this needing work
         if (isNato) {
           // Clean up if we are in NATO Enhancements
@@ -359,6 +360,7 @@
   };
 
   const getInfo = async ev => {
+    if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey) return;
     ev.preventDefault();
 
     const $tgt = $(ev.target);

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -360,7 +360,10 @@
   };
 
   const getInfo = async ev => {
-    if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey) return;
+    if (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey) {
+      return;
+    }
+
     ev.preventDefault();
 
     const $tgt = $(ev.target);


### PR DESCRIPTION
This makes the "smokey" quicklink added by the script into a proper link (by changing it from a `<button>` element into an `<a>` element). The styling and normal behavior both remain unchanged. Instead of behaving like the built-in "close" and "flag" quicklinks (which are `<button>` elements and only have an associated pop-up), the "smokey" quicklink now behaves like the built-in "share" and "edit" quicklinks. When clicked normally, the pop-up is displayed. When clicked with a meta key depressed and/or invoked with a context menu, it now works like a normal link, going to the associated MS page for the post. Obviously, if the post has not been reported to MS, then the link will not do anything useful, so this is a much less generally useful way of interacting with the "smokey" quicklink, but it is still useful in cases where you already know that a post has been reported to MS and want to quickly get the associated MS link opened in a new tab without waiting for the pop-up to load and make an API request.