### PR TITLE
FIRE 1.6.1

### DIFF
--- a/fire/README.md
+++ b/fire/README.md
@@ -120,6 +120,7 @@ installed. In order to fully reset, you would need to run this in the browser co
 |1.6    ||
 | ---   |---
 |1.6.0  |Copying to chat input upon <kbd>Alt</kbd>-<kbd>Click</kbd>. See above for a more detailed description.
+|1.6.1  |Adapt to SE supplying unexpected data when using the implicit OAuth 2.0 flow.
 
 |1.5    ||
 | ---   |---

--- a/fire/fire.meta.js
+++ b/fire/fire.meta.js
@@ -4,7 +4,7 @@
 // @description FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.
 // @author      Cerbrus [attribution: Michiel Dommerholt (https://github.com/Cerbrus)]
 // @contributor Makyen
-// @version     1.6.0
+// @version     1.6.1
 // @icon        https://raw.githubusercontent.com/Ranks/emojione-assets/master/png/32/1f525.png
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.user.js

--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -182,9 +182,15 @@
    */
   function checkHashForWriteToken() {
     if (location.hash && location.hash.length > 0) {
-      const result = location.hash.match(/#+access_token=(.+)/);
-      if (result) {
-        setValue('stackexchangeWriteToken', result[1]);
+      const params = new URLSearchParams(location.hash);
+      const token = params.get('#access_token');
+      if (token) {
+        /* 2023-08-11 SE is now providing the hash as:
+         *   #access_token=<token>&scope=write_access%20no_expiry
+         * It should be (https://api.stackexchange.com/docs/authentication):
+         *   #access_token=<token>
+         */
+        setValue('stackexchangeWriteToken', token);
         window.close();
       }
       // Clear hash

--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -4,7 +4,7 @@
 // @description FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.
 // @author      Cerbrus [attribution: Michiel Dommerholt (https://github.com/Cerbrus)]
 // @contributor Makyen
-// @version     1.6.0
+// @version     1.6.1
 // @icon        https://raw.githubusercontent.com/Ranks/emojione-assets/master/png/32/1f525.png
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.user.js

--- a/fire/package-lock.json
+++ b/fire/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fire",
-  "version": "1.4.0",
+  "version": "1.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/fire/package.json
+++ b/fire/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fire",
-  "version": "1.4.0",
+  "version": "1.6.1",
   "description": "FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.",
   "scripts": {
     "test": "xo",


### PR DESCRIPTION
This adapts to the additional data SE is now sending with the `access_token` when using the implicit OAuth 2.0 flow with the SE API.