### PR TITLE
FIRE 1.6.2: remove DOMSubtreeModified

### DIFF
--- a/fire/README.md
+++ b/fire/README.md
@@ -120,6 +120,7 @@ installed. In order to fully reset, you would need to run this in the browser co
 
 |1.6    ||
 | ---   |---
+|1.6.2  |Remove use of `DOMSubtreeModified` event , as it will be removed from Chrome shortly.
 |1.6.1  |Adapt to SE supplying unexpected data when using the implicit OAuth 2.0 flow.
 |1.6.0  |Copying to chat input upon <kbd>Alt</kbd>-<kbd>Click</kbd>. See above for a more detailed description.
 

--- a/fire/fire.meta.js
+++ b/fire/fire.meta.js
@@ -4,7 +4,7 @@
 // @description FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.
 // @author      Cerbrus [attribution: Michiel Dommerholt (https://github.com/Cerbrus)]
 // @contributor Makyen
-// @version     1.6.1
+// @version     1.6.2
 // @icon        https://raw.githubusercontent.com/Ranks/emojione-assets/master/png/32/1f525.png
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.user.js

--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -4741,9 +4741,17 @@ body.outside .fire-popup h2 {
    *
    */
   function showFireOnExistingMessages() {
-    $('#getmore, #getmore-mine')
-      .click(() => decorateExistingMessages(fire.constants.loadAllMessagesDelay));
+    $(document).ajaxComplete((event, jqXHR, ajaxSettings) => {
+      if (/^\/chats\/\d+\/events/i.test(ajaxSettings.url)) {
+        // By the time this gets called, the messages are in the DOM.
+        // The URL for getting message events is /chats/<room #>/events.
+        // This works in chat rooms for both the intial load of messages and
+        // getting additional messages.
+        decorateExistingMessages(0);
+      }
+    });
 
+    // This is needed in any other chat pages, other than actual chat rooms.
     decorateExistingMessages(0);
 
     // Load report data on fire button hover
@@ -4753,7 +4761,7 @@ body.outside .fire-popup h2 {
   }
 
   /**
-   * decorateExistingMessages - Decorate messages that exist on page load.
+   * decorateExistingMessages - Decorate any appropriate messages in the page which are not already decorated.
    *
    * @private
    * @memberof module:fire
@@ -4763,26 +4771,22 @@ body.outside .fire-popup h2 {
   function decorateExistingMessages(timeout) {
     const chat = $(/^\/(?:search|users)/.test(window.location.pathname) ? '#content' : '#chat,#transcript');
 
-    chat.one('DOMSubtreeModified', () => {
-      // We need another timeout here, because the first modification occurs before
-      // the new (old) chat messages are loaded.
-      setTimeout(() => {
-        if (chat.html().length === 0) { // Too soon
-          setTimeout(decorateExistingMessages, timeout, timeout);
-        } else { // Chat messages have loaded
-          $(fire.SDMessageSelector).each((i, element) => decorateMessage(element));
+    setTimeout(() => {
+      if (chat.html().length === 0) { // Too soon
+        setTimeout(decorateExistingMessages, timeout || fire.constants.millisecondsInSecond, timeout);
+      } else { // Chat messages have loaded
+        $(fire.SDMessageSelector).each((i, element) => decorateMessage(element));
 
-          fire.log('Decorated existing messages.');
+        fire.log('Decorated existing messages.');
 
-          /* eslint-disable no-warning-comments */
-          /*
-          TODO: Load Stack Exchange data for each report
-          updateReportCache();
-          */
-          /* eslint-enable no-warning-comments */
-        }
-      }, timeout);
-    });
+        /* eslint-disable no-warning-comments */
+        /*
+        TODO: Load Stack Exchange data for each report
+        updateReportCache();
+        */
+        /* eslint-enable no-warning-comments */
+      }
+    }, timeout);
     $(fire.SDMessageSelector).each((i, element) => decorateMessage(element));
   }
 

--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -4,7 +4,7 @@
 // @description FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.
 // @author      Cerbrus [attribution: Michiel Dommerholt (https://github.com/Cerbrus)]
 // @contributor Makyen
-// @version     1.6.1
+// @version     1.6.2
 // @icon        https://raw.githubusercontent.com/Ranks/emojione-assets/master/png/32/1f525.png
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.user.js


### PR DESCRIPTION
This removes the use of the `DOMSubtreeModified` event, which has been deprecated for a very long time, and which is scheduled for removal from Chrome in the very near future ([Chrome 127, on 2024-07-30](https://chromestatus.com/feature/5083947249172480)).