### PR TITLE
FIRE: fix: `revision_count` should not include revisions that do not correspond to an edit

### DIFF
--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -507,7 +507,7 @@
       (response) => {
         if (response && response.items) {
           report.se.revisions = response.items;
-          report.revision_count = response.items.length;
+          report.revision_count = response.items.filter((item) => item.revision_type === 'single_user').length;
 
           if (report.revision_count > 1) {
             showEditedIcon();


### PR DESCRIPTION
Occasionally, SD reports community wiki posts, or questions that are closed minutes after they are reported. FIRE considers these as "edited", even though they haven't been edited, due to the fact that events like bounties and CW/close notices are treated as new revisions by the SE API.

This PR excludes revisions [that do not correspond to an edit](https://meta.stackexchange.com/a/297262) from being counted in `revision_count`, which determines whether the pencil icon will appear in the FIRE popup.

See also: [Type revision](https://api.stackexchange.com/docs/types/revision) from the SE API docs.