### PR TITLE
Add `@license`

### DIFF
--- a/aeks/aeks.meta.js
+++ b/aeks/aeks.meta.js
@@ -4,7 +4,8 @@
 // @description Automatically enable keyboard shortcuts for any SE site you're on. This may require a reload for the setting to take effect.
 // @author      Cerbrus
 // @attribution Michiel Dommerholt (https://github.com/Cerbrus)
-// @version     1.1.0
+// @license     MIT OR Apache-2.0
+// @version     1.1.1
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/aeks/aeks.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/aeks/aeks.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/aeks/aeks.user.js
+++ b/aeks/aeks.user.js
@@ -4,7 +4,8 @@
 // @description Automatically enable keyboard shortcuts for any SE site you're on. This may require a reload for the setting to take effect.
 // @author      Cerbrus
 // @attribution Michiel Dommerholt (https://github.com/Cerbrus)
-// @version     1.1.0
+// @version     1.1.1
+// @license     MIT OR Apache-2.0
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/aeks/aeks.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/aeks/aeks.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/autoflagging/autoflagging.meta.js
+++ b/autoflagging/autoflagging.meta.js
@@ -8,7 +8,8 @@
 // @contributor ArtOfCode
 // @contributor Cerbrus
 // @contributor Makyen
-// @version     0.31
+// @version     0.32
+// @license     MIT OR Apache-2.0
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/autoflagging/autoflagging.user.js
+++ b/autoflagging/autoflagging.user.js
@@ -8,7 +8,8 @@
 // @contributor ArtOfCode
 // @contributor Cerbrus
 // @contributor Makyen
-// @version     0.31
+// @version     0.32
+// @license     MIT OR Apache-2.0
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/autoflagging/autoflagging.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/fdsc/fdsc.meta.js
+++ b/fdsc/fdsc.meta.js
@@ -8,7 +8,8 @@
 // @contributor J F
 // @contributor Glorfindel
 // @attribution Brock Adams (https://github.com/BrockA)
-// @version     1.20.6
+// @license     MIT OR Apache-2.0
+// @version     1.20.7
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fdsc/fdsc.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fdsc/fdsc.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/fdsc/fdsc.user.js
+++ b/fdsc/fdsc.user.js
@@ -8,7 +8,8 @@
 // @contributor J F
 // @contributor Glorfindel
 // @attribution Brock Adams (https://github.com/BrockA)
-// @version     1.20.6
+// @license     MIT OR Apache-2.0
+// @version     1.20.7
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fdsc/fdsc.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fdsc/fdsc.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/fire/fire.meta.js
+++ b/fire/fire.meta.js
@@ -4,7 +4,8 @@
 // @description FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.
 // @author      Cerbrus [attribution: Michiel Dommerholt (https://github.com/Cerbrus)]
 // @contributor Makyen
-// @version     1.6.2
+// @license     MIT OR Apache-2.0
+// @version     1.6.3
 // @icon        https://raw.githubusercontent.com/Ranks/emojione-assets/master/png/32/1f525.png
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.user.js

--- a/fire/fire.user.js
+++ b/fire/fire.user.js
@@ -4,7 +4,8 @@
 // @description FIRE adds a button to SmokeDetector reports that allows you to provide feedback & flag, all from chat.
 // @author      Cerbrus [attribution: Michiel Dommerholt (https://github.com/Cerbrus)]
 // @contributor Makyen
-// @version     1.6.2
+// @license     MIT OR Apache-2.0
+// @version     1.6.3
 // @icon        https://raw.githubusercontent.com/Ranks/emojione-assets/master/png/32/1f525.png
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/fire/fire.user.js

--- a/gas-mask-se/gas-mask-se.meta.js
+++ b/gas-mask-se/gas-mask-se.meta.js
@@ -13,5 +13,6 @@
 // @include       *://*superuser.com/*
 // @include       *://*stackapps.com/*
 // @include       *://*askubuntu.com/*
-// @version       1.3
+// @license       MIT OR Apache-2.0
+// @version       1.4
 // ==/UserScript==

--- a/gas-mask-se/gas-mask-se.user.js
+++ b/gas-mask-se/gas-mask-se.user.js
@@ -14,7 +14,8 @@
 // @include       *://*stackapps.com/*
 // @include       *://*askubuntu.com/*
 // @exclude       *://*stackoverflow.com/c/*
-// @version       1.3
+// @license       MIT OR Apache-2.0
+// @version       1.4
 // ==/UserScript==
 
 var style = document.createElement("style");

--- a/hideads/hideads.meta.js
+++ b/hideads/hideads.meta.js
@@ -16,6 +16,7 @@
 // @exclude     *://chat.stackoverflow.com/*
 // @exclude     *://blog.stackoverflow.com/*
 // @exclude     *://*.area51.stackexchange.com/*
-// @version     1.0
+// @license     MIT OR Apache-2.0
+// @version     1.1
 // @grant       none
 // ==/UserScript==

--- a/hideads/hideads.user.js
+++ b/hideads/hideads.user.js
@@ -16,7 +16,8 @@
 // @exclude     *://chat.stackoverflow.com/*
 // @exclude     *://blog.stackoverflow.com/*
 // @exclude     *://*.area51.stackexchange.com/*
-// @version     1.0
+// @license     MIT OR Apache-2.0
+// @version     1.1
 // @grant       none
 // ==/UserScript==
 

--- a/ms-dark-theme/ms_dark_theme.meta.js
+++ b/ms-dark-theme/ms_dark_theme.meta.js
@@ -2,7 +2,8 @@
 // @name         Dark themed metasmoke
 // @description  Enables the dark theme in production mode on metasmoke
 // @author       ArtOfCode
-// @version      0.1.0
+// @license      MIT OR Apache-2.0
+// @version      0.1.1
 // @match        *://metasmoke.erwaysoftware.com/*
 // @match        *://metasmoke.charcoal-se.org/*
 // @grant        none

--- a/ms-dark-theme/ms_dark_theme.user.js
+++ b/ms-dark-theme/ms_dark_theme.user.js
@@ -2,7 +2,8 @@
 // @name         Dark themed metasmoke
 // @description  Enables the dark theme in production mode on metasmoke
 // @author       ArtOfCode
-// @version      0.1.0
+// @license      MIT OR Apache-2.0
+// @version      0.1.1
 // @match        *://metasmoke.erwaysoftware.com/*
 // @match        *://metasmoke.charcoal-se.org/*
 // @grant        none

--- a/review-keyboard-shortcuts/review-shortcuts.user.js
+++ b/review-keyboard-shortcuts/review-shortcuts.user.js
@@ -2,7 +2,8 @@
 // @name        MS Review Keyboard Shortcuts
 // @description Adds keyboard shortcuts to the review queues on metasmoke.
 // @author      ArtOfCode
-// @version     0.2.2
+// @license     MIT OR Apache-2.0
+// @version     0.2.3
 // @namespace   charcoal-se.org
 // @match       https://metasmoke.erwaysoftware.com/review/*
 // @updateURL   https://github.com/Charcoal-SE/userscripts/raw/master/review-keyboard-shortcuts/review-shortcuts.user.js

--- a/sds/sds.meta.js
+++ b/sds/sds.meta.js
@@ -3,7 +3,8 @@
 // @namespace   https://github.com/Charcoal-SE/
 // @description Show the status of all SmokeDetector instances
 // @author      J F
-// @version     0.0.7
+// @license     MIT OR Apache-2.0
+// @version     0.0.8
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/sds/sds.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/sds/sds.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/sds/sds.user.js
+++ b/sds/sds.user.js
@@ -3,7 +3,8 @@
 // @namespace   https://github.com/Charcoal-SE/
 // @description Show the status of all SmokeDetector instances
 // @author      J F
-// @version     0.0.7
+// @license     MIT OR Apache-2.0
+// @version     0.0.8
 // @updateURL   https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/sds/sds.meta.js
 // @downloadURL https://raw.githubusercontent.com/Charcoal-SE/Userscripts/master/sds/sds.user.js
 // @supportURL  https://github.com/Charcoal-SE/Userscripts/issues

--- a/sim/sim.user.js
+++ b/sim/sim.user.js
@@ -1,7 +1,8 @@
 // ==UserScript==
 // @name         SIM - SmokeDetector Info for Moderators
 // @namespace    https://charcoal-se.org/
-// @version      1.8.1
+// @license      MIT OR Apache-2.0
+// @version      1.8.2
 // @description  Dig up information about how SmokeDetector handled a post.
 // @author       ArtOfCode
 // @contributor  Makyen

--- a/spam/SmokeyPings.user.js
+++ b/spam/SmokeyPings.user.js
@@ -3,7 +3,8 @@
 // @description Play the ping sound if Smokey has a message at the bottom of the SOCVR chat.
 // @author      Henders
 // @attribution Andy Henderson (https://github.com/SulphurDioxide)
-// @version     0.2.1
+// @license     MIT OR Apache-2.0
+// @version     0.2.2
 // @match       *://chat.stackexchange.com/rooms/11540/charcoal-hq*
 // @match       *://chat.stackoverflow.com/rooms/41570/so-close-vote-reviewers*
 // @match       *://chat.meta.stackexchange.com/rooms/89/tavern-on-the-meta*

--- a/spamtracker/spamtracker.meta.js
+++ b/spamtracker/spamtracker.meta.js
@@ -1,6 +1,7 @@
 // ==UserScript==
 // @name         Spamtracker
-// @version      1.1.0
+// @license      MIT OR Apache-2.0
+// @version      1.1.1
 // @description  Rewrite of the spamtracker project, this userscript will notify you using sound and a notification if a new spam post has been posted in any smoke detector supported rooms
 // @author       Ferrybig
 // @match        *://chat.meta.stackexchange.com/*

--- a/spamtracker/spamtracker.user.js
+++ b/spamtracker/spamtracker.user.js
@@ -1,6 +1,7 @@
 // ==UserScript==
 // @name         Spamtracker
-// @version      1.1.0
+// @license      MIT OR Apache-2.0
+// @version      1.1.1
 // @description  Rewrite of the spamtracker project, this userscript will notify you using sound and a notification if a new spam post has been posted in any smoke detector supported rooms
 // @author       Ferrybig
 // @match        *://chat.meta.stackexchange.com/*


### PR DESCRIPTION
I inferred `MIT OR Apache-2.0` from README.md.

Having a `@license` annotation allows me to more legally redestribute my ViolentMonkey .zip backups.